### PR TITLE
Fix readme for version 3.0.0.

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,9 @@ Add a dependency to your project with the following co-ordinates:
 
 ```xml
 <dependency>
-	<groupId>ch.mfrey.thymeleaf.extras.cache</groupId>
-	<artifactId>thymeleaf-cache-dialect</artifactId>
-	<version>2.0.0</version>
+  <groupId>ch.mfrey.thymeleaf.extras.cache</groupId>
+  <artifactId>thymeleaf-cache-dialect</artifactId>
+  <version>3.0.0</version>
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 Some parts of our webpage will never change during the lifetime of the application or a usersession, but the part should still be dynamic in the beginning. 
 
 Working with Thymeleaf 3.0.0+ (3.0.0.RELEASE and its dependencies included)</description>
-	<url>https://github.com/Antibrumm/thymeleaf-extras-cache</url>
+	<url>https://github.com/Antibrumm/thymeleaf-extras-cache-dialect</url>
 	<licenses>
 		<license>
 			<name>The Apache Software License, Version 2.0</name>


### PR DESCRIPTION
The version of Maven Dependency written in the README is incorrect.
Version2.0.0 jar is not found in Maven Central Repository.
And, the url written in pom.xml is incorrect.

Please review.